### PR TITLE
Upgrade sbt-docker to 1.4.1

### DIFF
--- a/sbt-application/project/plugins.sbt
+++ b/sbt-application/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")


### PR DESCRIPTION
This fixes issues with parsing the new naming scheme especially on macOS. See also

https://github.com/marcuslonnberg/sbt-docker/issues/60