### PR TITLE
Run `sbt-docker` in `sbt-application`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An example of using Semantive/Spark Docker image with sbt-docker plugin to creat
 2. [SBT](http://www.scala-sbt.org/)
 
 ## Running
-1. Create docker image of the sbt-application by executing following command inside ``docker-resources`` directory:
+1. Create docker image of the sbt-application by executing following command inside ``sbt-application`` directory:
 
 ```sbt docker```
 


### PR DESCRIPTION
Running `sbt docker` in `docker-resources` creates an error as there is no sbt project.Running the command in `sbt-application` instead.

```
sbt-application/docker-resources $ sbt docker 
[info] Loading global plugins from /Users/oschrenk/.tilde/dotfiles/.sbt/0.13/plugins
[info] Set current project to docker-resources (in build file:/Users/oschrenk/Projects/external/Spark-Docker-Example/sbt-application/docker-resources/)
[error] Not a valid command: docker
[error] Not a valid key: docker (similar: doc)
[error] docker
[error]       ^
```